### PR TITLE
Bump Version For NPM Release With Leak Timer Fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-pulse",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "React Native Pulse Animation",
   "main": "pulse.js",
   "scripts": {


### PR DESCRIPTION
Summary:
I'm still seeing the issue #2 occasionally. 

```
Warning: setState(...): Can only update a mounted or mounting component. This usually means you called setState() on an unmounted component. This is a no-op. Please check the code for the Pulse component.
```

I noticed that the timer leak #3 is not released via npm. This bumps
the version in order to make a release easy. :)

Thanks for creating this component!