### PR TITLE
Fix timeout not cleared upon unmounting

### DIFF
--- a/pulse.js
+++ b/pulse.js
@@ -53,7 +53,7 @@ class Pulse extends Component {
 
     let a = 0;
     while(a < this.state.numPulses){
-      setTimeout(()=>{
+      this.createPulseTimer = setTimeout(()=>{
         this._createPulse(a);
       }, a * this.state.duration);
       a++;
@@ -65,6 +65,7 @@ class Pulse extends Component {
   }
 
   componentWillUnmount(){
+    clearTimeout(this.createPulseTimer);
     clearInterval(this.timer);
   }
   


### PR DESCRIPTION
This fixes the error caused by timeout not cleared upon unmounting.

This is related to https://github.com/sahlhoff/react-native-pulse/issues/2 and https://github.com/sahlhoff/react-native-pulse/pull/3 (the previous fix missed this timeout).