### PR TITLE
PropTypes & React.createClass discontinuations

### DIFF
--- a/pulse.js
+++ b/pulse.js
@@ -1,7 +1,7 @@
 import React, {
-  Component,
-  PropTypes
+  Component
 } from 'react';
+import PropTypes from 'prop-types';
 import {
   View,
   Text,


### PR DESCRIPTION
React Native 0.49.x formally discontinues:

1. React.PropTypes
2. React.createClass