### PR TITLE
Implement pulseStyle prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # React Native Pulse Animation
 
 ![react native pulse](https://raw.githubusercontent.com/sahlhoff/react-native-pulse/master/pulse-gif.gif)
-  
+
 ## Installation
 
 ```
@@ -12,7 +12,7 @@
 
 ```js
 const Pulse = require('react-native-pulse');
-  
+
 class helloWorld extends Component {
   render() {
     return (
@@ -31,10 +31,11 @@ Component accepts several self-descriptive properties:
 
 
 - **`color`** _(String)_ - Backgroundcolor for pulse. React-native colors supported. Default color is blue.
-- **`numPulses`** _(Number)_ - This is the number of pulses that will be rendered. Defaults to 3.
 - **`diameter`** _(Number)_ - This is the maximum diameter that a pulse will be. Defaults to 400.
-- **`initialDiameter`** _(Number)_ - The diameter new pulses will start with. Defaults to 0.
-- **`style`** _(object)_ - Style properties for pulse container positioning eg.
-- **`image`** _(object)_ - Image for center pulse thumbnail.
-- **`speed`** _(Number)_ - Speed in milliseconds pulse will redraw. Defaults to 10.
 - **`duration`** _(Number)_ - Duration in milliseconds this is the delay new pulses will be created. Defaults to 1000.
+- **`image`** _(Object)_ - Image for center pulse thumbnail.
+- **`initialDiameter`** _(Number)_ - The diameter new pulses will start with. Defaults to 0.
+- **`numPulses`** _(Number)_ - This is the number of pulses that will be rendered. Defaults to 3.
+- **`pulseStyle`** _(Object)_ - Style properties for pulses (borderColor eg.)
+- **`speed`** _(Number)_ - Speed in milliseconds pulse will redraw. Defaults to 10.
+- **`style`** _(Object)_ - Style properties for pulse container (positioning eg.)

--- a/pulse.js
+++ b/pulse.js
@@ -23,57 +23,58 @@ const styles = StyleSheet.create({
 });
 
 export default class Pulse extends Component {
-
     static propTypes = {
-        style: PropTypes.object,
-        image: PropTypes.object,
         color: PropTypes.string,
-        numPulses: PropTypes.number,
         diameter: PropTypes.number,
+        duration: PropTypes.number,
+        image: PropTypes.object,
         initialDiameter: PropTypes.number,
+        numPulses: PropTypes.number,
+        pulseStyle: PropTypes.object,
         speed: PropTypes.number,
-        duration: PropTypes.number
+        style: PropTypes.object
     };
 
-
     static defaultProps = {
+        color: 'blue',
+        diameter: 400,
+        duration: 1000,
+        image: null,
+        initialDiameter: 0,
+        numPulses: 3,
+        pulseStyle: {},
+        speed: 10,
         style: {
             top: 0,
             bottom: 0,
             flexDirection: 'row',
             justifyContent: 'center',
             alignItems: 'center'
-        },
-        color: 'blue',
-        numPulses: 3,
-        diameter: 400,
-        initialDiameter: 0,
-        speed: 10,
-        duration: 1000
+        }
     }
 
     constructor(props){
         super(props);
 
         this.state = {
-            started: false,
-            style: this.props.style,
-            image: this.props.image,
             color: this.props.color,
-            numPulses: this.props.numPulses,
-            maxDiameter: this.props.diameter,
-            speed: this.props.speed,
             duration: this.props.duration,
-            pulses: []
+            image: this.props.image,
+            maxDiameter: this.props.diameter,
+            numPulses: this.props.numPulses,
+            pulses: [],
+            pulseStyle: this.props.pulseStyle,
+            speed: this.props.speed,
+            started: false,
+            style: this.props.style
         };
-
     }
 
     mounted = true;
-  
+
     componentDidMount(){
         const {numPulses, duration, speed} = this.state;
-        
+
         this.setState({started: true});
 
         let a = 0;
@@ -97,10 +98,9 @@ export default class Pulse extends Component {
     }
 
     createPulse = (pKey) => {
-
         if (this.mounted) {
             let pulses = this.state.pulses;
-        
+
             let pulse = {
                 pulseKey: pulses.length + 1,
                 diameter: this.props.initialDiameter,
@@ -112,18 +112,16 @@ export default class Pulse extends Component {
 
             this.setState({pulses});
         }
-
     }
 
     updatePulse = () => {
-
         if (this.mounted) {
             const pulses = this.state.pulses.map((p, i) => {
                 let maxDiameter = this.state.maxDiameter;
                 let newDiameter = (p.diameter > maxDiameter ? 0 : p.diameter + 2);
                 let centerOffset = ( maxDiameter - newDiameter ) / 2;
                 let opacity = Math.abs( ( newDiameter / this.state.maxDiameter ) - 1 );
-                
+
                 let pulse = {
                     pulseKey: i + 1,
                     diameter: newDiameter,
@@ -132,50 +130,49 @@ export default class Pulse extends Component {
                 };
 
                 return pulse;
-            
+
             });
 
             this.setState({pulses});
         }
-        
     }
-  
+
     render(){
-        const {style, image, maxDiameter, color, started, pulses} = this.state;
-        const wrapperStyle = [styles.container, style];
-        const containerStyle = {width: maxDiameter, height: maxDiameter};
+        const {color, image, maxDiameter, pulses, pulseStyle, started, style} = this.state;
+        const containerStyle = [styles.container, style];
+        const pulseWrapperStyle = {width: maxDiameter, height: maxDiameter};
 
         return (
-            <View style={wrapperStyle}>
+            <View style={containerStyle}>
                 {started &&
-                    <View style={containerStyle}>
-                        {pulses.map((pulse) => 
-                            <View 
-                                key={pulse.pulseKey} 
+                    <View style={pulseWrapperStyle}>
+                        {pulses.map((pulse) =>
+                            <View
+                                key={pulse.pulseKey}
                                 style={[
-                                    styles.pulse, 
+                                    styles.pulse,
                                     {
-                                        backgroundColor: color, 
-                                        width: pulse.diameter, 
-                                        height: pulse.diameter, 
-                                        opacity: pulse.opacity, 
+                                        backgroundColor: color,
+                                        width: pulse.diameter,
+                                        height: pulse.diameter,
+                                        opacity: pulse.opacity,
                                         borderRadius: pulse.diameter / 2,
-                                        top: pulse.centerOffset, 
+                                        top: pulse.centerOffset,
                                         left: pulse.centerOffset
-                                    } 
-                                ]} 
+                                    },
+                                    pulseStyle
+                                ]}
                             />
                         )}
                         {image &&
                             <Image
                                 style={image.style}
                                 source={image.source}
-                            /> 
+                            />
                         }
                     </View>
                 }
             </View>
         )
-
     }
 }


### PR DESCRIPTION
This PR implements the new `pulseStyle` prop so that we can have a little more flexibility with the way the pulses look.

For example you could do something like this to make the pulses have a borderColor without a background to have a sort of "pulsing rings" effect:

```jsx
<Pulse
  color=""
  numPulses={3}
  diameter={100}
  speed={20}
  duration={2000}
  pulseStyle={{ borderWidth: 3, borderColor: 'red' }} />
```

I also cleaned up a few small things such as removed double line-breaks/extra whitespaces as well as alphabetized object properties.

Thanks for the sweet component!